### PR TITLE
Return unknown status for jobs with no builds

### DIFF
--- a/HudsonServices/HudsonBuildStatus.cs
+++ b/HudsonServices/HudsonBuildStatus.cs
@@ -18,6 +18,15 @@ namespace HudsonServices
         {
             try
             {
+                BuildDefinitionId = buildDefinitionSetting.Id;
+                Name = buildDefinitionSetting.Name;
+                BuildStatusEnum = BuildStatusEnum.Unknown;
+                StartedTime = DateTime.MinValue;
+                FinishedTime = DateTime.MinValue;
+                RequestedBy = "No builds found";
+
+                if (doc == null) return;
+
                 if (doc.Root == null) throw new Exception("Could not get root of xml");
                 var changeSet = doc.Root.Element("changeSet");
                 if (changeSet == null) throw new Exception("Could not find 'changeSet'");
@@ -37,9 +46,6 @@ namespace HudsonServices
                         BuildStatusEnum = BuildStatusEnum.Unknown;
                     }
                 }
-
-                BuildDefinitionId = buildDefinitionSetting.Id;
-                Name = buildDefinitionSetting.Name;
 
                 var changeSetItem = changeSet.Element("item");
                 string timestamp = doc.Root.ElementValueOrDefault("timestamp");

--- a/HudsonServices/HudsonService.cs
+++ b/HudsonServices/HudsonService.cs
@@ -88,7 +88,7 @@ namespace HudsonServices
                 var lastBuildElem = doc.Root.Element("lastBuild");
                 if (lastBuildElem == null)
                 {
-                    throw new ServerUnavailableException("No 'lastBuild' element found for " + buildDefinitionSetting + " is the server in maintenence mode or something?");
+                    return new HudsonBuildStatus(null, buildDefinitionSetting);
                 }
                 var buildNumber = lastBuildElem.ElementValueOrDefault("number");
                 var buildUrl = rootUrl + "/job/" + buildDefinitionSetting.Id + "/" + buildNumber;


### PR DESCRIPTION
When a job that had no builds was added to the job list to be
monitored, it would result in the error "Build Server Unavailable"
and no jobs would be monitored. Changed this functionality to
return an unknown status so it wouldn't interfere with the other
jobs.
