### PR TITLE
TeamCityBuildUnavailableFix super quick

### DIFF
--- a/SirenOfShame.Lib/Watcher/WebClientXml.cs
+++ b/SirenOfShame.Lib/Watcher/WebClientXml.cs
@@ -107,6 +107,12 @@ namespace SirenOfShame.Lib.Watcher
                 return TryParseXmlResult(url, resultString);
             } catch (WebException webException)
             {
+                if (url.Contains("httpAuth/app/rest/builds/buildType:"))
+                {
+                    _log.Error(webException.Message, webException);
+                    return null;
+                }
+
                 throw ToServerUnavailableException(url, webException);
             }
         }

--- a/TeamCityServices/TeamCityService.cs
+++ b/TeamCityServices/TeamCityService.cs
@@ -370,8 +370,24 @@ namespace TeamCityServices
             try
             {
                 XDocument doc = DownloadXml(url, userName, password);
-                if (doc.Root == null) throw new Exception("Could not get project build status");
-                return GetBuildStatusAndCommentsFromXDocument(rootUrl, userName, password, buildDefinitionSetting, doc);
+                if (doc == null)
+                {
+                    _log.ErrorFormat("Could not get project build status for {0}", url);
+                    return new TeamCityBuildStatus(buildDefinitionSetting);
+                }
+                else if (doc.Root == null)
+                {
+                   throw new Exception("Could not get project build status");
+                }
+                else
+                {
+                    return GetBuildStatusAndCommentsFromXDocument(
+                        rootUrl,
+                        userName,
+                        password,
+                        buildDefinitionSetting,
+                        doc);
+                }
             }
             catch (BuildDefinitionNotFoundException)
             {


### PR DESCRIPTION
TeamCityBuildUnavailableFix super quick (but potentially dirty) fix to have siren of shame to stop breaking when one build definition is unavailable on team city.
Please review bearing in mind i did not look for any other implications;
