### PR TITLE
fix where broken builds were always newly broken on start up

### DIFF
--- a/AppVeyorServices/AppVeyorBuildStatus.cs
+++ b/AppVeyorServices/AppVeyorBuildStatus.cs
@@ -12,13 +12,13 @@ namespace AppVeyorServices
         {
             BuildDefinitionId = buildDefinitionSetting.Id;
             Name = "{0} ({1})".Fmt(project.Name, build.Version);
-            BuildStatusEnum = BuildStatusEnum.Unknown;
+            CurrentBuildStatus = BuildStatusEnum.Unknown;
             StartedTime = build.Started;
             FinishedTime = build.Finished;
             BuildStatusMessage = build.Status;
             Url = buildUrl;
             BuildId = build.BuildId;
-            BuildStatusEnum = ToBuildStatusEnum(build.Status);
+            CurrentBuildStatus = ToBuildStatusEnum(build.Status);
             RequestedBy = (string.IsNullOrEmpty(build.AuthorName)) ? build.AuthorName : build.CommitterName;
             Comment = build.Message;
         }

--- a/BambooServices/BambooBuildStatus.cs
+++ b/BambooServices/BambooBuildStatus.cs
@@ -18,7 +18,7 @@ namespace BambooServices
             {
                 BuildDefinitionId = buildDefinitionSetting.Id,
                 Name = buildDefinitionSetting.Name,
-                BuildStatusEnum = BuildStatusEnum.InProgress
+                CurrentBuildStatus = BuildStatusEnum.InProgress
             };
 
             DateTime startTime;
@@ -51,7 +51,7 @@ namespace BambooServices
             result.StartedTime = ParseDateTime(doc.Root.ElementValueOrDefault("buildStartedTime"));
             result.FinishedTime = ParseDateTime(doc.Root.ElementValueOrDefault("buildCompletedTime"));
 
-            result.BuildStatusEnum = ToBuildStatusEnum(stateStr);
+            result.CurrentBuildStatus = ToBuildStatusEnum(stateStr);
 
             var changesElem = doc.Root.Element("changes");
             if (changesElem != null)

--- a/BuildBotServices/BuildBotBuildStatus.cs
+++ b/BuildBotServices/BuildBotBuildStatus.cs
@@ -296,7 +296,7 @@ namespace BuildBotServices
 
             if (buildInProgress)
             {
-                BuildStatusEnum = BuildStatusEnum.InProgress;
+                CurrentBuildStatus = BuildStatusEnum.InProgress;
             }
             else
             {
@@ -305,20 +305,20 @@ namespace BuildBotServices
                     List<object> text = mostRecentBuild.text;
                     if (text.Contains("successful"))
                     {
-                        BuildStatusEnum = BuildStatusEnum.Working;
+                        CurrentBuildStatus = BuildStatusEnum.Working;
                     }
                     else if (text.Contains("failed"))
                     {
-                        BuildStatusEnum = BuildStatusEnum.Broken;
+                        CurrentBuildStatus = BuildStatusEnum.Broken;
                     }
                     else
                     {
-                        BuildStatusEnum = BuildStatusEnum.Unknown;
+                        CurrentBuildStatus = BuildStatusEnum.Unknown;
                     }
                 }
                 catch( Exception )
                 {
-                    BuildStatusEnum = BuildStatusEnum.Unknown;
+                    CurrentBuildStatus = BuildStatusEnum.Unknown;
                 }
             }
 
@@ -374,7 +374,7 @@ namespace BuildBotServices
             Url = webUrl.ToString();
             BuildId = mostRecentBuild.number.ToString();
 
-            buildStatusInfo.LastBuildStatusEnum = BuildStatusEnum;
+            buildStatusInfo.LastBuildStatusEnum = CurrentBuildStatus;
         }
 
         private ArrayList GetProperty(string propertyName, dynamic buildStatus)

--- a/HudsonServices/HudsonBuildStatus.cs
+++ b/HudsonServices/HudsonBuildStatus.cs
@@ -63,12 +63,12 @@ namespace HudsonServices
             var resultStr = docRoot.ElementValueOrDefault("result");
             if (!string.IsNullOrWhiteSpace(resultStr))
             {
-                BuildStatusEnum = ToBuildStatusEnum(resultStr, treatUnstableAsSuccess);
+                CurrentBuildStatus = ToBuildStatusEnum(resultStr, treatUnstableAsSuccess);
             }
             else
             {
                 var building = docRoot.ElementValueOrDefault("building");
-                BuildStatusEnum = string.Equals(building, "true", StringComparison.InvariantCultureIgnoreCase)
+                CurrentBuildStatus = string.Equals(building, "true", StringComparison.InvariantCultureIgnoreCase)
                                       ? BuildStatusEnum.InProgress
                                       : BuildStatusEnum.Unknown;
             }
@@ -190,7 +190,7 @@ namespace HudsonServices
         {
             BuildDefinitionId = buildDefinitionSetting.Id;
             Name = buildDefinitionSetting.Name;
-            BuildStatusEnum = BuildStatusEnum.Unknown;
+            CurrentBuildStatus = BuildStatusEnum.Unknown;
             StartedTime = null;
             FinishedTime = null;
             BuildStatusMessage = defaultBuildStatusMessage ?? string.Empty;

--- a/MockCiServerServices/MockCiServerForm.cs
+++ b/MockCiServerServices/MockCiServerForm.cs
@@ -48,7 +48,7 @@ namespace MockCiServerServices
             {
                 yield return new BuildStatus
                 {
-                    BuildStatusEnum = BuildStatusEnum.Working,
+                    CurrentBuildStatus = BuildStatusEnum.Working,
                     Name = "Build " + i,
                     StartedTime = startedTime,
                     FinishedTime = startedTime.AddMinutes(1).AddSeconds(2),

--- a/MockCiServerServices/MockProject.cs
+++ b/MockCiServerServices/MockProject.cs
@@ -44,7 +44,7 @@ namespace MockCiServerServices
                     {
                         Name = ProjectName,
                         BuildDefinitionId = ProjectId,
-                        BuildStatusEnum = _buildStatus,
+                        CurrentBuildStatus = _buildStatus,
                         Comment = _comment.Text,
                         FinishedTime = _finishedTime,
                         StartedTime = _startedTime,

--- a/SirenOfShame.Lib/Achievements/AndGotAwayWithIt.cs
+++ b/SirenOfShame.Lib/Achievements/AndGotAwayWithIt.cs
@@ -25,7 +25,7 @@ namespace SirenOfShame.Lib.Achievements
             var currentBuild = _currentBuildDefinitionOrderedChronoligically[count - 1];
             var previousBuild = _currentBuildDefinitionOrderedChronoligically[count - 2];
             bool currentAndLastBuildByCurrentUser = previousBuild.RequestedBy == PersonSetting.RawName && currentBuild.RequestedBy == PersonSetting.RawName;
-            bool wasJustFixed = previousBuild.BuildStatusEnum == BuildStatusEnum.Broken && currentBuild.BuildStatusEnum == BuildStatusEnum.Working;
+            bool wasJustFixed = previousBuild.CurrentBuildStatus == BuildStatusEnum.Broken && currentBuild.CurrentBuildStatus == BuildStatusEnum.Working;
             bool fixedWithinSixtySeconds = previousBuild.IsBackToBackWithNextBuild(currentBuild, 60);
             return currentAndLastBuildByCurrentUser && wasJustFixed && fixedWithinSixtySeconds;
         }

--- a/SirenOfShame.Lib/Achievements/LikeLightning.cs
+++ b/SirenOfShame.Lib/Achievements/LikeLightning.cs
@@ -25,7 +25,7 @@ namespace SirenOfShame.Lib.Achievements
             var lastThree = _currentBuildDefinitionOrderedChronoligically.Skip(_currentBuildDefinitionOrderedChronoligically.Count - 3).ToList();
             if (!lastThree.All(i => i.RequestedBy == PersonSetting.RawName)) return false;
             if (!lastThree.All(i => i.StartedTime.HasValue && i.FinishedTime.HasValue)) return false;
-            if (!lastThree.All(i => i.BuildStatusEnum == BuildStatusEnum.Working)) return false;
+            if (!lastThree.All(i => i.CurrentBuildStatus == BuildStatusEnum.Working)) return false;
             BuildStatus oldestBuild = lastThree[0];
             BuildStatus middleBuild = lastThree[1];
             BuildStatus mostRecentBuild = lastThree[2];

--- a/SirenOfShame.Lib/Achievements/Macgyver.cs
+++ b/SirenOfShame.Lib/Achievements/Macgyver.cs
@@ -26,14 +26,14 @@ namespace SirenOfShame.Lib.Achievements
             int count = _currentBuildDefinitionOrderedChronoligically.Count;
             if (count < 2) return false;
             var currentBuild = _currentBuildDefinitionOrderedChronoligically[count - 1];
-            if (currentBuild.BuildStatusEnum != BuildStatusEnum.Working)
+            if (currentBuild.CurrentBuildStatus != BuildStatusEnum.Working)
             {
                 _log.Debug("Only working builds are eligible for Macgyver achievements");
                 return false;
             }
             var lastSuccessfulBuild = _currentBuildDefinitionOrderedChronoligically
                 .Take(count - 1)
-                .LastOrDefault(i => i.BuildStatusEnum == BuildStatusEnum.Working && i.FinishedTime != null && i.StartedTime != null);
+                .LastOrDefault(i => i.CurrentBuildStatus == BuildStatusEnum.Working && i.FinishedTime != null && i.StartedTime != null);
             if (lastSuccessfulBuild == null)
             {
                 _log.Debug("Could not find a previous build that was working with a start and end time for " + currentBuild.BuildDefinitionId);

--- a/SirenOfShame.Lib/Achievements/ReputationRebound.cs
+++ b/SirenOfShame.Lib/Achievements/ReputationRebound.cs
@@ -33,11 +33,11 @@ namespace SirenOfShame.Lib.Achievements
                 if (achievedThreeConsecurtiveFails.HasValue && buildStatus.RequestedBy == PersonSetting.RawName)
                 {
                     buildsSinceThreeConsecutiveFails++;
-                    if (buildStatus.BuildStatusEnum == BuildStatusEnum.Broken)
+                    if (buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken)
                         failedSinceThreeConsecutiveFails++;
                 }
                 
-                if (buildStatus.RequestedBy == PersonSetting.RawName && buildStatus.BuildStatusEnum == BuildStatusEnum.Broken)
+                if (buildStatus.RequestedBy == PersonSetting.RawName && buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken)
                 {
                     consecutiveFailedBuilds++;
                     if (consecutiveFailedBuilds >= 3)

--- a/SirenOfShame.Lib/Settings/BuildDefinitionSetting.cs
+++ b/SirenOfShame.Lib/Settings/BuildDefinitionSetting.cs
@@ -47,7 +47,7 @@ namespace SirenOfShame.Lib.Settings {
 	        
             return new BuildStatus
 	        {
-	            BuildStatusEnum = BuildStatusEnum.Unknown,
+	            CurrentBuildStatus = BuildStatusEnum.Unknown,
 	            BuildDefinitionId = Id,
 	            Name = Name,
                 StartedTime = startedTime,

--- a/SirenOfShame.Lib/Settings/Rule.cs
+++ b/SirenOfShame.Lib/Settings/Rule.cs
@@ -162,18 +162,18 @@ namespace SirenOfShame.Lib.Settings
 
         private bool IsTriggerTypeMatch(BuildStatus buildStatus, bool newlyBroken, bool newlyFixed)
         {
-            if (TriggerType == TriggerType.BuildFailed && buildStatus.BuildStatusEnum == BuildStatusEnum.Broken) return true;
+            if (TriggerType == TriggerType.BuildFailed && buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken) return true;
             if (TriggerType == TriggerType.InitialFailedBuild       && newlyBroken) return true;
             if (TriggerType == TriggerType.InitialSuccess           && newlyFixed) return true;
-            if (TriggerType == TriggerType.BuildTriggered           && buildStatus.BuildStatusEnum == BuildStatusEnum.InProgress) return true;
-            if (TriggerType == TriggerType.SubsequentFailedBuild    && buildStatus.BuildStatusEnum == BuildStatusEnum.Broken && !newlyBroken) return true;
-            if (TriggerType == TriggerType.SuccessfulBuild          && buildStatus.BuildStatusEnum == BuildStatusEnum.Working && !newlyFixed) return true;
+            if (TriggerType == TriggerType.BuildTriggered           && buildStatus.CurrentBuildStatus == BuildStatusEnum.InProgress) return true;
+            if (TriggerType == TriggerType.SubsequentFailedBuild    && buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken && !newlyBroken) return true;
+            if (TriggerType == TriggerType.SuccessfulBuild          && buildStatus.CurrentBuildStatus == BuildStatusEnum.Working && !newlyFixed) return true;
             return false;
         }
 
         public void FireAnyUntilBuildPassesEvents(RulesEngine rulesEngine, BuildStatus buildStatus, BuildStatusEnum? previousStatus)
         {
-            bool newlyFixed = buildStatus.BuildStatusEnum == BuildStatusEnum.Working && previousStatus != null && previousStatus != BuildStatusEnum.Working;
+            bool newlyFixed = buildStatus.CurrentBuildStatus == BuildStatusEnum.Working && previousStatus != null && previousStatus != BuildStatusEnum.Working;
 
             if (PlayAudio && PlayAudioUntilBuildPasses && newlyFixed)
             {
@@ -202,30 +202,30 @@ namespace SirenOfShame.Lib.Settings
                 message = "Build is passing again";
                 okText = "Yayy!";
             }
-            if (buildStatus.BuildStatusEnum == BuildStatusEnum.InProgress)
+            if (buildStatus.CurrentBuildStatus == BuildStatusEnum.InProgress)
             {
                 message = "Build triggered by " + buildStatus.RequestedBy;
                 okText = "Ok, whatever";
             }
-            if (buildStatus.BuildStatusEnum == BuildStatusEnum.Broken && !newlyBroken)
+            if (buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken && !newlyBroken)
             {
                 message = "Build still broken";
                 okText = "Rats";
             }
-            if (buildStatus.BuildStatusEnum == BuildStatusEnum.Working && !newlyFixed)
+            if (buildStatus.CurrentBuildStatus == BuildStatusEnum.Working && !newlyFixed)
             {
                 message = "Build passed";
                 okText = "Yayy!";
             }
             message += " for " + buildStatus.Name;
-            if (buildStatus.BuildStatusEnum == BuildStatusEnum.InProgress && !string.IsNullOrEmpty(buildStatus.Comment))
+            if (buildStatus.CurrentBuildStatus == BuildStatusEnum.InProgress && !string.IsNullOrEmpty(buildStatus.Comment))
             {
                 message += "\r\n" + buildStatus.Comment;
             }
 
-            if (AlertType == AlertType.TrayAlert && !(previousStatus == null && buildStatus.BuildStatusEnum == BuildStatusEnum.Working))
+            if (AlertType == AlertType.TrayAlert && !(previousStatus == null && buildStatus.CurrentBuildStatus == BuildStatusEnum.Working))
             {
-                rulesEngine.InvokeTrayNotify(buildStatus.BuildStatusEnum == BuildStatusEnum.Broken ? ToolTipIcon.Error : ToolTipIcon.Info, string.Format("Build {0}", buildStatus.BuildStatusDescription), message);
+                rulesEngine.InvokeTrayNotify(buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken ? ToolTipIcon.Error : ToolTipIcon.Info, string.Format("Build {0}", buildStatus.BuildStatusDescription), message);
             }
 
             if (LedPattern != null)

--- a/SirenOfShame.Lib/StatCalculators/BackToBackBuilds.cs
+++ b/SirenOfShame.Lib/StatCalculators/BackToBackBuilds.cs
@@ -40,8 +40,8 @@ namespace SirenOfShame.Lib.StatCalculators
                 bool currentBuildIsByActivePerson = buildStatus.RequestedBy == activePerson.RawName;
                 if (lastBuildWasByActivePerson && currentBuildIsByActivePerson)
                 {
-                    bool lastBuildPassed = lastBuild.BuildStatusEnum == BuildStatusEnum.Working;
-                    bool currentBuildPassed = buildStatus.BuildStatusEnum == BuildStatusEnum.Working;
+                    bool lastBuildPassed = lastBuild.CurrentBuildStatus == BuildStatusEnum.Working;
+                    bool currentBuildPassed = buildStatus.CurrentBuildStatus == BuildStatusEnum.Working;
                     bool wereBackToBack = lastBuild.IsBackToBackWithNextBuild(buildStatus);
                     if (lastBuildPassed && currentBuildPassed && wereBackToBack)
                     {

--- a/SirenOfShame.Lib/StatCalculators/BuildRatio.cs
+++ b/SirenOfShame.Lib/StatCalculators/BuildRatio.cs
@@ -22,7 +22,7 @@ namespace SirenOfShame.Lib.StatCalculators
         {
             var currentUserBuilds = allActiveBuildDefinitionsOrderedChronoligically.Where(i => i.RequestedBy == personSetting.RawName).ToList();
             var totalBuilds = currentUserBuilds.Count;
-            var unsuccessfulBuilds = currentUserBuilds.Count(i => i.BuildStatusEnum == BuildStatusEnum.Broken);
+            var unsuccessfulBuilds = currentUserBuilds.Count(i => i.CurrentBuildStatus == BuildStatusEnum.Broken);
             return totalBuilds == 0 ? 0 : (double)unsuccessfulBuilds/totalBuilds;
         }
 
@@ -40,7 +40,7 @@ namespace SirenOfShame.Lib.StatCalculators
             foreach (var buildStatus in buildStatuses)
             {
                 totalBuilds++;
-                if (buildStatus.BuildStatusEnum == BuildStatusEnum.Broken)
+                if (buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken)
                     unsuccessfulBuilds++;
                 currentRatio = (double)unsuccessfulBuilds / totalBuilds;
                 if (totalBuilds == 50)

--- a/SirenOfShame.Lib/StatCalculators/FixedSomeoneElsesBuild.cs
+++ b/SirenOfShame.Lib/StatCalculators/FixedSomeoneElsesBuild.cs
@@ -27,9 +27,9 @@ namespace SirenOfShame.Lib.StatCalculators
             string buildInitiallyBrokenBy = null;
             foreach (var buildStatus in currentBuildDefinitionOrderedChronoligically)
             {
-                bool newlyBroken = buildStatus.BuildStatusEnum == BuildStatusEnum.Broken && buildInitiallyBrokenBy == null;
+                bool newlyBroken = buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken && buildInitiallyBrokenBy == null;
                 bool wasBrokenLastTime = buildInitiallyBrokenBy != null;
-                bool newlyFixed = wasBrokenLastTime && buildStatus.BuildStatusEnum == BuildStatusEnum.Working;
+                bool newlyFixed = wasBrokenLastTime && buildStatus.CurrentBuildStatus == BuildStatusEnum.Working;
 
                 if (newlyBroken)
                 {

--- a/SirenOfShame.Lib/StatCalculators/SuccessInARow.cs
+++ b/SirenOfShame.Lib/StatCalculators/SuccessInARow.cs
@@ -17,7 +17,7 @@ namespace SirenOfShame.Lib.StatCalculators
             return allActiveBuildDefinitionsOrderedChronoligically
                 .Reverse()
                 .Where(i => i.RequestedBy == personSetting.RawName)
-                .TakeWhile(i => i.BuildStatusEnum != BuildStatusEnum.Broken)
+                .TakeWhile(i => i.CurrentBuildStatus != BuildStatusEnum.Broken)
                 .Count();
         }
     }

--- a/SirenOfShame.Lib/Util/BuildStatusUtil.cs
+++ b/SirenOfShame.Lib/Util/BuildStatusUtil.cs
@@ -18,12 +18,12 @@ namespace SirenOfShame.Lib.Util
             var newBuildStatusesToAdd = newBuildStatuses.Except(oldBuildStatuses, buildStatusComparer);
             var unchangedBuildStatuses = from oldStatus in oldBuildStatuses
                                          join newStatus in newBuildStatuses on oldStatus.BuildDefinitionId equals newStatus.BuildDefinitionId
-                                         where newStatus.BuildStatusEnum == oldStatus.BuildStatusEnum &&
+                                         where newStatus.CurrentBuildStatus == oldStatus.CurrentBuildStatus &&
                                             newStatus.StartedTime == oldStatus.StartedTime
                                          select oldStatus;
             var changedBuildStatuses = from oldStatus in oldBuildStatuses
                                        join newStatus in newBuildStatuses on oldStatus.BuildDefinitionId equals newStatus.BuildDefinitionId
-                                       where newStatus.BuildStatusEnum != oldStatus.BuildStatusEnum ||
+                                       where newStatus.CurrentBuildStatus != oldStatus.CurrentBuildStatus ||
                                             newStatus.StartedTime != oldStatus.StartedTime
                                        select newStatus;
             return oldBuildStatusesToRetain.Union(newBuildStatusesToAdd).Union(unchangedBuildStatuses).Union(changedBuildStatuses).ToArray();

--- a/SirenOfShame.Lib/Watcher/RulesEngine.cs
+++ b/SirenOfShame.Lib/Watcher/RulesEngine.cs
@@ -308,7 +308,7 @@ namespace SirenOfShame.Lib.Watcher
             if (oldStatus == null) return true;
 
             bool startTimesUnequal = oldStatus.StartedTime != newStatus.StartedTime;
-            bool buildStatusesUnequal = oldStatus.BuildStatusEnum != newStatus.BuildStatusEnum;
+            bool buildStatusesUnequal = oldStatus.CurrentBuildStatus != newStatus.CurrentBuildStatus;
            bool buildChanged = 
                 startTimesUnequal || buildStatusesUnequal;
             
@@ -319,8 +319,8 @@ namespace SirenOfShame.Lib.Watcher
                     newStatus.BuildDefinitionId, 
                     oldStatus.StartedTime, 
                     newStatus.StartedTime, 
-                    oldStatus.BuildStatusEnum, 
-                    newStatus.BuildStatusEnum,
+                    oldStatus.CurrentBuildStatus, 
+                    newStatus.CurrentBuildStatus,
                     newStatus.BuildId,
                     newStatus.RequestedBy
                     );
@@ -362,7 +362,7 @@ namespace SirenOfShame.Lib.Watcher
 
         private void TimerTick(object sender, EventArgs e)
         {
-            if (_previousBuildStatuses.Any(bs => bs.BuildStatusEnum == BuildStatusEnum.InProgress))
+            if (_previousBuildStatuses.Any(bs => bs.CurrentBuildStatus == BuildStatusEnum.InProgress))
             {
                 InvokeRefreshStatus(_previousBuildStatuses);
             }
@@ -461,7 +461,7 @@ namespace SirenOfShame.Lib.Watcher
             BuildStatus previousWorkingOrBrokenBuildStatus;
             dictionary.TryGetValue(changedBuildStatus.BuildDefinitionId, out previousWorkingOrBrokenBuildStatus);
 
-            return previousWorkingOrBrokenBuildStatus == null ? (BuildStatusEnum?)null : previousWorkingOrBrokenBuildStatus.BuildStatusEnum;
+            return previousWorkingOrBrokenBuildStatus == null ? (BuildStatusEnum?)null : previousWorkingOrBrokenBuildStatus.CurrentBuildStatus;
         }
 
         private static void SetValue(BuildStatus changedBuildStatus, IDictionary<string, BuildStatus> dictionary)
@@ -486,7 +486,7 @@ namespace SirenOfShame.Lib.Watcher
                                            select new { buildStatus, setting };
             bool anyBuildBroken = buildStatusesAndSettings
                 .Any(bs => bs.setting.AffectsTrayIcon && (
-                    bs.buildStatus.BuildStatusEnum == BuildStatusEnum.Broken));
+                    bs.buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken));
             TrayIcon trayIcon = anyBuildBroken ? TrayIcon.Red : TrayIcon.Green;
             InvokeSetTrayIcon(trayIcon);
         }

--- a/SirenOfShame.Lib/Watcher/SosDb.cs
+++ b/SirenOfShame.Lib/Watcher/SosDb.cs
@@ -41,7 +41,7 @@ namespace SirenOfShame.Lib.Watcher
         {
             if (string.IsNullOrEmpty(buildStatus.RequestedBy)) return;
             var personSetting = settings.FindAddPerson(buildStatus.RequestedBy);
-            if (buildStatus.BuildStatusEnum == BuildStatusEnum.Broken)
+            if (buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken)
             {
                 personSetting.FailedBuilds++;
             }
@@ -55,7 +55,7 @@ namespace SirenOfShame.Lib.Watcher
             {
                 buildStatus.StartedTime == null ? "" : buildStatus.StartedTime.Value.Ticks.ToString(CultureInfo.InvariantCulture),
                 buildStatus.FinishedTime == null ? "" : buildStatus.FinishedTime.Value.Ticks.ToString(CultureInfo.InvariantCulture),
-                ((int) buildStatus.BuildStatusEnum).ToString(CultureInfo.InvariantCulture),
+                ((int) buildStatus.CurrentBuildStatus).ToString(CultureInfo.InvariantCulture),
                 buildStatus.RequestedBy
             };
             string contents = string.Join(",", items) + "\r\n";

--- a/SirenOfShame.Test.Unit/Achievements/AndGotAwayWithItTest.cs
+++ b/SirenOfShame.Test.Unit/Achievements/AndGotAwayWithItTest.cs
@@ -16,8 +16,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting {RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { RequestedBy = "currentUser", FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1), BuildStatusEnum = BuildStatusEnum.Broken },
-                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 1, 59), BuildStatusEnum = BuildStatusEnum.Working },
+                new BuildStatus { RequestedBy = "currentUser", FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1), CurrentBuildStatus = BuildStatusEnum.Broken },
+                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 1, 59), CurrentBuildStatus = BuildStatusEnum.Working },
             };
             Assert.IsTrue(new AndGotAwayWithIt(personSetting, builds).HasJustAchieved());
         }
@@ -28,8 +28,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting {RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { RequestedBy = "someoneElse", FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1), BuildStatusEnum = BuildStatusEnum.Broken },
-                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 1, 59), BuildStatusEnum = BuildStatusEnum.Working },
+                new BuildStatus { RequestedBy = "someoneElse", FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1), CurrentBuildStatus = BuildStatusEnum.Broken },
+                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 1, 59), CurrentBuildStatus = BuildStatusEnum.Working },
             };
             Assert.IsFalse(new AndGotAwayWithIt(personSetting, builds).HasJustAchieved());
         }
@@ -40,8 +40,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting {RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { RequestedBy = "currentUser", FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1), BuildStatusEnum = BuildStatusEnum.Broken },
-                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 1, 59), BuildStatusEnum = BuildStatusEnum.Broken },
+                new BuildStatus { RequestedBy = "currentUser", FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1), CurrentBuildStatus = BuildStatusEnum.Broken },
+                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 1, 59), CurrentBuildStatus = BuildStatusEnum.Broken },
             };
             Assert.IsFalse(new AndGotAwayWithIt(personSetting, builds).HasJustAchieved());
         }
@@ -52,8 +52,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting {RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { RequestedBy = "currentUser", FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1), BuildStatusEnum = BuildStatusEnum.Broken },
-                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 2, 1), BuildStatusEnum = BuildStatusEnum.Working },
+                new BuildStatus { RequestedBy = "currentUser", FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1), CurrentBuildStatus = BuildStatusEnum.Broken },
+                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 2, 1), CurrentBuildStatus = BuildStatusEnum.Working },
             };
             Assert.IsFalse(new AndGotAwayWithIt(personSetting, builds).HasJustAchieved());
         }
@@ -64,8 +64,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting {RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Broken },
-                new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Working },
+                new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Broken },
+                new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Working },
             };
             Assert.IsFalse(new AndGotAwayWithIt(personSetting, builds).HasJustAchieved());
         }
@@ -76,7 +76,7 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting {RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 1, 59), BuildStatusEnum = BuildStatusEnum.Working },
+                new BuildStatus { RequestedBy = "currentUser", StartedTime = new DateTime(2010, 1, 1, 1, 1, 59), CurrentBuildStatus = BuildStatusEnum.Working },
             };
             Assert.IsFalse(new AndGotAwayWithIt(personSetting, builds).HasJustAchieved());
         }

--- a/SirenOfShame.Test.Unit/Achievements/ArribaArribaAndaleAndaleTest.cs
+++ b/SirenOfShame.Test.Unit/Achievements/ArribaArribaAndaleAndaleTest.cs
@@ -16,8 +16,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, BuildDefinitionId = "1", RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, BuildDefinitionId = "1", RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, BuildDefinitionId = "1", RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, BuildDefinitionId = "1", RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
             };
             Assert.AreEqual(1, BackToBackBuilds.HowManyTimesHasPerformedBackToBackBuildsAcrossBuilds(fakePersonSetting, builds));
         }
@@ -28,8 +28,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, BuildDefinitionId = "1", RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, BuildDefinitionId = "2", RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, BuildDefinitionId = "1", RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, BuildDefinitionId = "2", RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
             };
             Assert.AreEqual(0, BackToBackBuilds.HowManyTimesHasPerformedBackToBackBuildsAcrossBuilds(fakePersonSetting, builds));
         }
@@ -40,8 +40,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
             };
             Assert.AreEqual(1, BackToBackBuilds.HowManyTimesHasPerformedBackToBackBuildsForABuild(fakePersonSetting, builds));
         }
@@ -52,14 +52,14 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
                 
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 3, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 3, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 3, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 3, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 3, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 3, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 3, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 3, 2, 4, 3)},
                 
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 4, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 4, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 4, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 4, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 4, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 4, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 4, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 4, 2, 4, 3)},
             };
             Assert.AreEqual(3, BackToBackBuilds.HowManyTimesHasPerformedBackToBackBuildsForABuild(fakePersonSetting, builds));
         }
@@ -70,8 +70,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "someoneElse", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "someoneElse", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
             };
             Assert.AreEqual(0, BackToBackBuilds.HowManyTimesHasPerformedBackToBackBuildsForABuild(fakePersonSetting, builds));
         }
@@ -82,8 +82,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
             };
             Assert.AreEqual(0, BackToBackBuilds.HowManyTimesHasPerformedBackToBackBuildsForABuild(fakePersonSetting, builds));
         }
@@ -94,8 +94,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 3, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 3, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 3, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 3, 4, 3)},
             };
             Assert.AreEqual(0, BackToBackBuilds.HowManyTimesHasPerformedBackToBackBuildsForABuild(fakePersonSetting, builds));
         }

--- a/SirenOfShame.Test.Unit/Achievements/CiNinjaTest.cs
+++ b/SirenOfShame.Test.Unit/Achievements/CiNinjaTest.cs
@@ -13,8 +13,8 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             var currentBuildDefinitionOrderedChronoligically = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, BuildDefinitionId = "1", RequestedBy = "someoneElse" },
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, BuildDefinitionId = "1", RequestedBy = "currentUser" }
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, BuildDefinitionId = "1", RequestedBy = "someoneElse" },
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, BuildDefinitionId = "1", RequestedBy = "currentUser" }
             };
             Assert.AreEqual(1, FixedSomeoneElsesBuild.HowManyTimesFixedSomeoneElsesBuildForAllBuilds(currentBuildDefinitionOrderedChronoligically, "currentUser"));
         }
@@ -24,8 +24,8 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             var currentBuildDefinitionOrderedChronoligically = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, BuildDefinitionId = "1", RequestedBy = "someoneElse" },
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, BuildDefinitionId = "2", RequestedBy = "currentUser" }
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, BuildDefinitionId = "1", RequestedBy = "someoneElse" },
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, BuildDefinitionId = "2", RequestedBy = "currentUser" }
             };
             Assert.AreEqual(0, FixedSomeoneElsesBuild.HowManyTimesFixedSomeoneElsesBuildForAllBuilds(currentBuildDefinitionOrderedChronoligically, "currentUser"));
         }
@@ -42,8 +42,8 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             var currentBuildDefinitionOrderedChronoligically = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "someoneElse" },
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser" }
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "someoneElse" },
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser" }
             };
             Assert.AreEqual(1, FixedSomeoneElsesBuild.HowManyTimesHasFixedSomeoneElsesBuildForBuild(currentBuildDefinitionOrderedChronoligically, "currentUser"));
         }
@@ -53,8 +53,8 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             var currentBuildDefinitionOrderedChronoligically = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser" },
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser" }
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser" },
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser" }
             };
             Assert.AreEqual(0, FixedSomeoneElsesBuild.HowManyTimesHasFixedSomeoneElsesBuildForBuild(currentBuildDefinitionOrderedChronoligically, "currentUser"));
         }
@@ -64,8 +64,8 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             var currentBuildDefinitionOrderedChronoligically = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser" },
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "someoneElse" }
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser" },
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "someoneElse" }
             };
             Assert.AreEqual(0, FixedSomeoneElsesBuild.HowManyTimesHasFixedSomeoneElsesBuildForBuild(currentBuildDefinitionOrderedChronoligically, "currentUser"));
         }
@@ -75,9 +75,9 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             var currentBuildDefinitionOrderedChronoligically = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "someoneElse" },
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser" },
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser" },
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "someoneElse" },
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser" },
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser" },
             };
             Assert.AreEqual(1, FixedSomeoneElsesBuild.HowManyTimesHasFixedSomeoneElsesBuildForBuild(currentBuildDefinitionOrderedChronoligically, "currentUser"));
         }

--- a/SirenOfShame.Test.Unit/Achievements/CriticalTest.cs
+++ b/SirenOfShame.Test.Unit/Achievements/CriticalTest.cs
@@ -15,11 +15,11 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             PersonSetting personSetting = new PersonSetting { RawName = "currentUser" };
             List<BuildStatus> builds = new List<BuildStatus>();
-            builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Broken });
-            builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Working });
-            builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Working });
-            builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Working });
-            builds.Add(new BuildStatus { RequestedBy = "someoneElse", BuildStatusEnum = BuildStatusEnum.Working });
+            builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Broken });
+            builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Working });
+            builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Working });
+            builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Working });
+            builds.Add(new BuildStatus { RequestedBy = "someoneElse", CurrentBuildStatus = BuildStatusEnum.Working });
             Assert.AreEqual(0.25, BuildRatio.CalculateCurrentBuildRatio(personSetting, builds));
         }
 
@@ -28,10 +28,10 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             PersonSetting personSetting = new PersonSetting { RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>();
-            builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Broken });
+            builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Broken });
             for (int i = 0; i < 49; i++)
             {
-                builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Working });
+                builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Working });
             }
             Assert.AreEqual(50, builds.Count);
             Assert.AreEqual(0.02, BuildRatio.CalculateLowestBuildRatioAfter50Builds(personSetting, builds));
@@ -42,10 +42,10 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             PersonSetting personSetting = new PersonSetting { RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>();
-            builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Broken });
+            builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Broken });
             for (int i = 0; i < 99; i++)
             {
-                builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Working });
+                builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Working });
             }
             Assert.AreEqual(100, builds.Count);
             Assert.AreEqual(0.01, BuildRatio.CalculateLowestBuildRatioAfter50Builds(personSetting, builds));
@@ -56,14 +56,14 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             PersonSetting personSetting = new PersonSetting { RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>();
-            builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Broken });
+            builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Broken });
             for (int i = 0; i < 49; i++)
             {
-                builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Working });
+                builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Working });
             }
             for (int i = 0; i < 50; i++)
             {
-                builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Broken });
+                builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Broken });
             }
             Assert.AreEqual(100, builds.Count);
             Assert.AreEqual(0.02, BuildRatio.CalculateLowestBuildRatioAfter50Builds(personSetting, builds));
@@ -74,10 +74,10 @@ namespace SirenOfShame.Test.Unit.Achievements
         {
             PersonSetting personSetting = new PersonSetting { RawName = "currentUser"};
             List<BuildStatus> builds = new List<BuildStatus>();
-            builds.Add(new BuildStatus { RequestedBy = "someoneElse", BuildStatusEnum = BuildStatusEnum.Broken });
+            builds.Add(new BuildStatus { RequestedBy = "someoneElse", CurrentBuildStatus = BuildStatusEnum.Broken });
             for (int i = 0; i < 49; i++)
             {
-                builds.Add(new BuildStatus { RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Working });
+                builds.Add(new BuildStatus { RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Working });
             }
             Assert.AreEqual(50, builds.Count);
             Assert.IsNull(BuildRatio.CalculateLowestBuildRatioAfter50Builds(personSetting, builds));

--- a/SirenOfShame.Test.Unit/Achievements/LikeLightningTest.cs
+++ b/SirenOfShame.Test.Unit/Achievements/LikeLightningTest.cs
@@ -16,9 +16,9 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 14), FinishedTime = new DateTime(2010, 2, 2, 2, 5, 14)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 14), FinishedTime = new DateTime(2010, 2, 2, 2, 5, 14)},
             };
             Assert.AreEqual(false, new LikeLightning(fakePersonSetting, builds).HasJustAchieved());
         }
@@ -29,9 +29,9 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 4), FinishedTime = new DateTime(2010, 2, 2, 2, 5, 4)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 4), FinishedTime = new DateTime(2010, 2, 2, 2, 5, 4)},
             };
             Assert.AreEqual(true, new LikeLightning(fakePersonSetting, builds).HasJustAchieved());
         }
@@ -42,9 +42,9 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 4), FinishedTime = new DateTime(2010, 2, 2, 2, 5, 4)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 4), FinishedTime = new DateTime(2010, 2, 2, 2, 5, 4)},
             };
             Assert.AreEqual(false, new LikeLightning(fakePersonSetting, builds).HasJustAchieved());
         }
@@ -55,9 +55,9 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 4), FinishedTime = null},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 4), FinishedTime = null},
             };
             Assert.AreEqual(false, new LikeLightning(fakePersonSetting, builds).HasJustAchieved());
         }
@@ -78,9 +78,9 @@ namespace SirenOfShame.Test.Unit.Achievements
             var fakePersonSetting = new PersonSetting { RawName = "currentUser" };
             var builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "someoneElse", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 4), FinishedTime = new DateTime(2010, 2, 2, 2, 5, 4)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 2, 2), FinishedTime = new DateTime(2010, 2, 2, 2, 3, 2)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "someoneElse", StartedTime = new DateTime(2010, 2, 2, 2, 3, 3), FinishedTime = new DateTime(2010, 2, 2, 2, 4, 3)},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser", StartedTime = new DateTime(2010, 2, 2, 2, 4, 4), FinishedTime = new DateTime(2010, 2, 2, 2, 5, 4)},
             };
             Assert.AreEqual(false, new LikeLightning(fakePersonSetting, builds).HasJustAchieved());
         }

--- a/SirenOfShame.Test.Unit/Achievements/MacgyverTest.cs
+++ b/SirenOfShame.Test.Unit/Achievements/MacgyverTest.cs
@@ -16,8 +16,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting person = new PersonSetting {RawName = "CurrentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), BuildStatusEnum = BuildStatusEnum.Working},
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 29), BuildStatusEnum = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), CurrentBuildStatus = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 29), CurrentBuildStatus = BuildStatusEnum.Working},
             };
             Assert.AreEqual(100, builds[0].GetDuration().Value.TotalSeconds);
             Assert.AreEqual(89, builds[1].GetDuration().Value.TotalSeconds);
@@ -30,8 +30,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting person = new PersonSetting {RawName = "CurrentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), BuildStatusEnum = BuildStatusEnum.Working},
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 24), BuildStatusEnum = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), CurrentBuildStatus = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 24), CurrentBuildStatus = BuildStatusEnum.Working},
             };
             Assert.AreEqual(100, builds[0].GetDuration().Value.TotalSeconds);
             Assert.AreEqual(84, builds[1].GetDuration().Value.TotalSeconds);
@@ -44,8 +44,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting person = new PersonSetting {RawName = "CurrentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = null, BuildStatusEnum = BuildStatusEnum.Working},
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 29), BuildStatusEnum = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = null, CurrentBuildStatus = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 29), CurrentBuildStatus = BuildStatusEnum.Working},
             };
             Assert.IsFalse(new Macgyver(person, builds).HasJustAchieved());
         }
@@ -56,8 +56,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting person = new PersonSetting {RawName = "CurrentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), BuildStatusEnum = BuildStatusEnum.Working},
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 29), BuildStatusEnum = BuildStatusEnum.Broken},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), CurrentBuildStatus = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 29), CurrentBuildStatus = BuildStatusEnum.Broken},
             };
             Assert.AreEqual(100, builds[0].GetDuration().Value.TotalSeconds);
             Assert.AreEqual(89, builds[1].GetDuration().Value.TotalSeconds);
@@ -70,9 +70,9 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting person = new PersonSetting {RawName = "CurrentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), BuildStatusEnum = BuildStatusEnum.Working},
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 5, 00), BuildStatusEnum = BuildStatusEnum.Broken},
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 3, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 3, 2, 40), BuildStatusEnum = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), CurrentBuildStatus = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 5, 00), CurrentBuildStatus = BuildStatusEnum.Broken},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 3, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 3, 2, 40), CurrentBuildStatus = BuildStatusEnum.Working},
             };
             Assert.AreEqual(100, builds[0].GetDuration().Value.TotalSeconds);
             Assert.AreEqual(240, builds[1].GetDuration().Value.TotalSeconds);
@@ -86,8 +86,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting person = new PersonSetting {RawName = "CurrentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), BuildStatusEnum = BuildStatusEnum.Working},
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 51), BuildStatusEnum = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), CurrentBuildStatus = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 51), CurrentBuildStatus = BuildStatusEnum.Working},
             };
             Assert.AreEqual(100, builds[0].GetDuration().Value.TotalSeconds);
             Assert.AreEqual(111, builds[1].GetDuration().Value.TotalSeconds);
@@ -100,8 +100,8 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting person = new PersonSetting {RawName = "CurrentUser"};
             List<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), BuildStatusEnum = BuildStatusEnum.Working},
-                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 31), BuildStatusEnum = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 1, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 1, 2, 40), CurrentBuildStatus = BuildStatusEnum.Working},
+                new BuildStatus { StartedTime = new DateTime(2010, 1, 1, 2, 1, 0), FinishedTime = new DateTime(2010, 1, 1, 2, 2, 31), CurrentBuildStatus = BuildStatusEnum.Working},
             };
             Assert.AreEqual(100, builds[0].GetDuration().Value.TotalSeconds);
             Assert.AreEqual(91, builds[1].GetDuration().Value.TotalSeconds);

--- a/SirenOfShame.Test.Unit/Achievements/ReputationReboundTest.cs
+++ b/SirenOfShame.Test.Unit/Achievements/ReputationReboundTest.cs
@@ -15,21 +15,21 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting { RawName = "currentUser"};
             List<BuildStatus> buildStatuses = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
             };
             Assert.AreEqual(true, new ReputationRebound(personSetting, buildStatuses).HasJustAchieved());
         }
@@ -40,20 +40,20 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting { RawName = "currentUser"};
             List<BuildStatus> buildStatuses = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
             };
             Assert.AreEqual(false, new ReputationRebound(personSetting, buildStatuses).HasJustAchieved());
         }
@@ -64,20 +64,20 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting { RawName = "currentUser"};
             List<BuildStatus> buildStatuses = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
             };
             Assert.AreEqual(false, new ReputationRebound(personSetting, buildStatuses).HasJustAchieved());
         }
@@ -88,21 +88,21 @@ namespace SirenOfShame.Test.Unit.Achievements
             PersonSetting personSetting = new PersonSetting { RawName = "currentUser"};
             List<BuildStatus> buildStatuses = new List<BuildStatus>
             {
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "currentUser"},
-                new BuildStatus { BuildStatusEnum = BuildStatusEnum.Working, RequestedBy = "someoneElse"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Broken, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "currentUser"},
+                new BuildStatus { CurrentBuildStatus = BuildStatusEnum.Working, RequestedBy = "someoneElse"},
             };
             Assert.AreEqual(false, new ReputationRebound(personSetting, buildStatuses).HasJustAchieved());
         }

--- a/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/BambooBuildStatusTest.cs
+++ b/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/BambooBuildStatusTest.cs
@@ -19,7 +19,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             buildDefinitionSetting.Id = "BuildDefinitionId";
             var buildStatus = BambooBuildStatus.CreateBuildResult(bambooFailingBuild, buildDefinitionSetting, "http://win7ci:8085");
 
-            Assert.AreEqual(BuildStatusEnum.Broken, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Broken, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("BuildDefinitionId", buildStatus.BuildDefinitionId);
             Assert.AreEqual("Name", buildStatus.Name);
             Assert.AreEqual("Lee", buildStatus.RequestedBy);

--- a/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/CruiseControlNetBuildStatusTest.cs
+++ b/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/CruiseControlNetBuildStatusTest.cs
@@ -29,7 +29,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             CruiseControlNetBuildStatus.ClearCache();
             CruiseControlNetBuildStatus buildStatus = new CruiseControlNetBuildStatus(projectElement, null);
 
-            Assert.AreEqual(BuildStatusEnum.Broken, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Broken, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("Lee", buildStatus.RequestedBy);
             Assert.IsNotNull(buildStatus.StartedTime);
             AssertAreClose(new DateTime(2012, 8, 16, 19, 23, 34, 276), buildStatus.StartedTime.Value);
@@ -56,7 +56,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             CruiseControlNetBuildStatus.ClearCache();
             CruiseControlNetBuildStatus buildStatus = new CruiseControlNetBuildStatus(projectElement, null);
 
-            Assert.AreEqual(BuildStatusEnum.InProgress, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.InProgress, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("CruiseControlNetProj1", buildStatus.BuildDefinitionId);
             Assert.AreEqual("CruiseControlNetProj1", buildStatus.Name);
             Assert.AreEqual(null, buildStatus.RequestedBy);
@@ -83,7 +83,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             new CruiseControlNetBuildStatus(notInProgressStatusProjectElement, null);
             CruiseControlNetBuildStatus buildStatus = new CruiseControlNetBuildStatus(inProgressStatusProjectElement, null);
 
-            Assert.AreEqual(BuildStatusEnum.InProgress, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.InProgress, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("CruiseControlNetProj1", buildStatus.BuildDefinitionId);
             Assert.AreEqual("CruiseControlNetProj1", buildStatus.Name);
             Assert.AreEqual(null, buildStatus.RequestedBy);
@@ -107,7 +107,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             new CruiseControlNetBuildStatus(projectElement, null);
             CruiseControlNetBuildStatus buildStatus = new CruiseControlNetBuildStatus(projectElement, null);
 
-            Assert.AreEqual(BuildStatusEnum.Unknown, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Unknown, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("CruiseControlNetProj1", buildStatus.BuildDefinitionId);
             Assert.AreEqual("CruiseControlNetProj1", buildStatus.Name);
             Assert.AreEqual(null, buildStatus.RequestedBy);

--- a/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/HudsonBuildStatusTest.cs
+++ b/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/HudsonBuildStatusTest.cs
@@ -18,7 +18,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             buildDefinitionSetting.Name = "Name";
             buildDefinitionSetting.Id = "BuildDefinitionId";
             HudsonBuildStatus buildStatus = new HudsonBuildStatus(jenkinsUnstable, buildDefinitionSetting, null, treatUnstableAsSuccess: true);
-            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.CurrentBuildStatus);
         }
 
         [Test]
@@ -29,7 +29,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             buildDefinitionSetting.Name = "Name";
             buildDefinitionSetting.Id = "BuildDefinitionId";
             HudsonBuildStatus buildStatus = new HudsonBuildStatus(jenkinsUnstable, buildDefinitionSetting, null, treatUnstableAsSuccess: false);
-            Assert.AreEqual(BuildStatusEnum.Broken, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Broken, buildStatus.CurrentBuildStatus);
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             buildDefinitionSetting.Id = "BuildDefinitionId";
             HudsonBuildStatus buildStatus = new HudsonBuildStatus(jenkinsBuildStatusForIssue10, buildDefinitionSetting, null, treatUnstableAsSuccess: false);
             
-            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("BuildDefinitionId", buildStatus.BuildDefinitionId);
             Assert.AreEqual("Name", buildStatus.Name);
             Assert.AreEqual("anonymous", buildStatus.RequestedBy);
@@ -61,7 +61,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             buildDefinitionSetting.Id = "BuildDefinitionId";
             HudsonBuildStatus buildStatus = new HudsonBuildStatus(jenkinsBuildStatusForIssue10, buildDefinitionSetting, null, treatUnstableAsSuccess: false);
 
-            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("BuildDefinitionId", buildStatus.BuildDefinitionId);
             Assert.AreEqual("Name", buildStatus.Name);
             Assert.AreEqual("STCO", buildStatus.RequestedBy);
@@ -81,7 +81,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             buildDefinitionSetting.Id = "BuildDefinitionId";
             HudsonBuildStatus buildStatus = new HudsonBuildStatus(jenkinsBuildStatusForIssue10, buildDefinitionSetting, null, treatUnstableAsSuccess: false);
 
-            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.CurrentBuildStatus);
             Assert.AreEqual(null, buildStatus.RequestedBy);
 
             // 2/15/2012 5:00:54 PM

--- a/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/TeamCityBuildStatusTest.cs
+++ b/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/TeamCityBuildStatusTest.cs
@@ -23,7 +23,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             };
             var buildStatus = new TeamCityBuildStatus(buildDefinitionSetting, buildInfo, changeInfo);
 
-            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("BuildDefinitionId", buildStatus.BuildDefinitionId);
             Assert.AreEqual("Tests", buildStatus.Name);
             Assert.AreEqual("someone@somewhere.com", buildStatus.RequestedBy);
@@ -48,7 +48,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             };
             var buildStatus = new TeamCityBuildStatus(buildDefinitionSetting, teamCityFailingBuild, teamCityFailingChange);
 
-            Assert.AreEqual(BuildStatusEnum.Broken, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Broken, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("BuildDefinitionId", buildStatus.BuildDefinitionId);
             Assert.AreEqual("BuildConfig4", buildStatus.Name);
             Assert.AreEqual("lee", buildStatus.RequestedBy);
@@ -74,7 +74,7 @@ Conflicts:
             };
             var buildStatus = new TeamCityBuildStatus(buildDefinitionSetting, teamCityFailureDueToCleanup, null);
 
-            Assert.AreEqual(BuildStatusEnum.Unknown, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Unknown, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("BuildDefinitionId", buildStatus.BuildDefinitionId);
             Assert.AreEqual("db_maintenance Database [GRAVIS1]", buildStatus.Name);
             Assert.AreEqual(null, buildStatus.RequestedBy);

--- a/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/TfsRestBuildStatusTest.cs
+++ b/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/TfsRestBuildStatusTest.cs
@@ -85,7 +85,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             var build = jsonWrapper.Value[1];
             var commentsCache = GetCommentsCache(build.Definition.Id, build.Id, "My comment");
             var buildStatus = new TfsRestBuildStatus(build, commentsCache);
-            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("2", buildStatus.BuildDefinitionId);
             Assert.AreEqual("TestingGitTfsOnlineSolution", buildStatus.Name);
             Assert.AreEqual("Lee Richardson", buildStatus.RequestedBy);

--- a/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/TravisCiBuildStatusTest.cs
+++ b/SirenOfShame.Test.Unit/CIEntryPointBuildStatus/TravisCiBuildStatusTest.cs
@@ -19,7 +19,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             buildDefinitionSetting.Id = "BuildDefinitionId";
             TravisCiBuildStatus buildStatus = new TravisCiBuildStatus(travisCiBuildDefinition, travisCiWorkingBuild, buildDefinitionSetting);
 
-            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("BuildDefinitionId", buildStatus.BuildDefinitionId);
             Assert.AreEqual("Name", buildStatus.Name);
             Assert.AreEqual("Bob Smith", buildStatus.RequestedBy);
@@ -38,7 +38,7 @@ namespace SirenOfShame.Test.Unit.CIEntryPointBuildStatus
             buildDefinitionSetting.Id = "BuildDefinitionId";
             TravisCiBuildStatus buildStatus = new TravisCiBuildStatus(travisCiBuildDefinition, travisCiWorkingBuild, buildDefinitionSetting);
 
-            Assert.AreEqual(BuildStatusEnum.InProgress, buildStatus.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.InProgress, buildStatus.CurrentBuildStatus);
             Assert.AreEqual("BuildDefinitionId", buildStatus.BuildDefinitionId);
             Assert.AreEqual("Name", buildStatus.Name);
             Assert.AreEqual("Garima Singh", buildStatus.RequestedBy);

--- a/SirenOfShame.Test.Unit/StatCalculators/SuccessInARowTest.cs
+++ b/SirenOfShame.Test.Unit/StatCalculators/SuccessInARowTest.cs
@@ -14,8 +14,8 @@ namespace SirenOfShame.Test.Unit.StatCalculators
         {
             IEnumerable<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildDefinitionId = "1", RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Broken },
-                new BuildStatus { BuildDefinitionId = "1", RequestedBy = "currentUser", BuildStatusEnum = BuildStatusEnum.Working },
+                new BuildStatus { BuildDefinitionId = "1", RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Broken },
+                new BuildStatus { BuildDefinitionId = "1", RequestedBy = "currentUser", CurrentBuildStatus = BuildStatusEnum.Working },
             };
             var actual = SuccessInARow.CalculateSuccessInARow(new PersonSetting {RawName = "currentUser"}, builds);
             Assert.AreEqual(1, actual);
@@ -26,8 +26,8 @@ namespace SirenOfShame.Test.Unit.StatCalculators
         {
             IEnumerable<BuildStatus> builds = new List<BuildStatus>
             {
-                new BuildStatus { BuildDefinitionId = "1", RequestedBy = "someoneElse", BuildStatusEnum = BuildStatusEnum.Broken },
-                new BuildStatus { BuildDefinitionId = "1", RequestedBy = "someoneElse", BuildStatusEnum = BuildStatusEnum.Working },
+                new BuildStatus { BuildDefinitionId = "1", RequestedBy = "someoneElse", CurrentBuildStatus = BuildStatusEnum.Broken },
+                new BuildStatus { BuildDefinitionId = "1", RequestedBy = "someoneElse", CurrentBuildStatus = BuildStatusEnum.Working },
             };
             var actual = SuccessInARow.CalculateSuccessInARow(new PersonSetting {RawName = "currentUser"}, builds);
             Assert.AreEqual(0, actual);

--- a/SirenOfShame.Test.Unit/Util/BuildStatusUtilTest.cs
+++ b/SirenOfShame.Test.Unit/Util/BuildStatusUtilTest.cs
@@ -13,17 +13,17 @@ namespace SirenOfShame.Test.Unit.Util
         public void Merge_NewBuildStatus_Added()
         {
             var oldStatus = new BuildStatus[] {};
-            var newStatuses = new[] {new BuildStatus {BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working}};
+            var newStatuses = new[] {new BuildStatus {BuildDefinitionId = "1", CurrentBuildStatus = BuildStatusEnum.Working}};
             var result = BuildStatusUtil.Merge(oldStatus, newStatuses);
             Assert.AreEqual(1, result.Count());
             Assert.AreEqual("1", result[0].BuildDefinitionId);
-            Assert.AreEqual(BuildStatusEnum.Working, result[0].BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, result[0].CurrentBuildStatus);
         }
         
         [Test]
         public void Merge_RemovedBuildStatus_Retained()
         {
-            var oldStatus = new[] {new BuildStatus {BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working}};
+            var oldStatus = new[] {new BuildStatus {BuildDefinitionId = "1", CurrentBuildStatus = BuildStatusEnum.Working}};
             var newStatuses = new BuildStatus[] {};
             var result = BuildStatusUtil.Merge(oldStatus, newStatuses);
             Assert.AreEqual(1, result.Count());
@@ -32,12 +32,12 @@ namespace SirenOfShame.Test.Unit.Util
         [Test]
         public void Merge_ExistingUnchangedBuildStatus_NotOverwritten()
         {
-            var oldStatus = new[] { new BuildStatus { BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working, LocalStartTime = new DateTime(2010, 1, 1) } };
-            var newStatuses = new[] { new BuildStatus { BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working, LocalStartTime = new DateTime(2012, 2, 2)} };
+            var oldStatus = new[] { new BuildStatus { BuildDefinitionId = "1", CurrentBuildStatus = BuildStatusEnum.Working, LocalStartTime = new DateTime(2010, 1, 1) } };
+            var newStatuses = new[] { new BuildStatus { BuildDefinitionId = "1", CurrentBuildStatus = BuildStatusEnum.Working, LocalStartTime = new DateTime(2012, 2, 2)} };
             var result = BuildStatusUtil.Merge(oldStatus, newStatuses);
             Assert.AreEqual(1, result.Count());
             Assert.AreEqual("1", result[0].BuildDefinitionId);
-            Assert.AreEqual(BuildStatusEnum.Working, result[0].BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, result[0].CurrentBuildStatus);
             Assert.AreEqual(new DateTime(2010, 1, 1), result[0].LocalStartTime);
         }
     }

--- a/SirenOfShame.Test.Unit/Watcher/BuildStatusTest.cs
+++ b/SirenOfShame.Test.Unit/Watcher/BuildStatusTest.cs
@@ -30,7 +30,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             Assert.AreEqual(new DateTime(2012, 1, 1, 1, 1, 1), actual.StartedTime);
             Assert.AreEqual(new DateTime(2012, 2, 2, 2, 2, 2), actual.FinishedTime);
             Assert.AreEqual("jshimpty", actual.RequestedBy);
-            Assert.AreEqual(BuildStatusEnum.Working, actual.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Working, actual.CurrentBuildStatus);
             Assert.AreEqual("buildid", actual.BuildDefinitionId);
         }
 
@@ -81,7 +81,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             {
                 BuildDefinitionId = "MyBuild",
                 LocalStartTime = new DateTime(2010, 1, 1, 1, 1, 1),
-                BuildStatusEnum = BuildStatusEnum.InProgress
+                CurrentBuildStatus = BuildStatusEnum.InProgress
             };
             var now = new DateTime(2010, 1, 1, 1, 2, 2);
             var previousWorkingOrBrokenBuildStatus = new Dictionary<string, BuildStatus>();
@@ -97,7 +97,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             {
                 BuildDefinitionId = "MyBuild",
                 LocalStartTime = new DateTime(2010, 1, 1, 1, 1, 1),
-                BuildStatusEnum = BuildStatusEnum.InProgress
+                CurrentBuildStatus = BuildStatusEnum.InProgress
             };
             var now = new DateTime(2010, 1, 1, 1, 1, 1);
             var previousWorkingOrBrokenBuildStatus = new Dictionary<string, BuildStatus>
@@ -121,7 +121,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             {
                 BuildDefinitionId = "MyBuild",
                 LocalStartTime = new DateTime(2010, 1, 1, 1, 1, 1),
-                BuildStatusEnum = BuildStatusEnum.InProgress
+                CurrentBuildStatus = BuildStatusEnum.InProgress
             };
             var now = new DateTime(2010, 1, 1, 1, 3, 2);
             

--- a/SirenOfShame.Test.Unit/Watcher/RulesEngineTest.cs
+++ b/SirenOfShame.Test.Unit/Watcher/RulesEngineTest.cs
@@ -30,7 +30,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             var rulesEngine = new RulesEngineWrapper();
             var build1 = new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.InProgress,
+                CurrentBuildStatus = BuildStatusEnum.InProgress,
                 Name = RulesEngineWrapper.BUILD1_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -40,7 +40,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             };
             var build2 = new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.InProgress,
+                CurrentBuildStatus = BuildStatusEnum.InProgress,
                 Name = RulesEngineWrapper.BUILD2_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD2_ID,
@@ -59,7 +59,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             var rulesEngine = new RulesEngineWrapper();
             var build1 = new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.InProgress,
+                CurrentBuildStatus = BuildStatusEnum.InProgress,
                 Name = RulesEngineWrapper.BUILD1_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -69,7 +69,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             };
             var build2 = new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.InProgress,
+                CurrentBuildStatus = BuildStatusEnum.InProgress,
                 Name = RulesEngineWrapper.BUILD2_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD2_ID,
@@ -113,7 +113,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             AssertTrayIconCountAndLastColor(rulesEngine.SetTrayIconEvents, 1, TrayIcon.Question);
             var buildStatus = new BuildStatus
                 {
-                    BuildStatusEnum = BuildStatusEnum.Working,
+                    CurrentBuildStatus = BuildStatusEnum.Working,
                     Name = RulesEngineWrapper.BUILD1_ID,
                     RequestedBy = RulesEngineWrapper.CURRENT_USER,
                     BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -153,7 +153,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             rulesEngine.InvokeStatusChecked(BuildStatusEnum.Working);
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.InProgress,
+                CurrentBuildStatus = BuildStatusEnum.InProgress,
                 Name = "Name",
                 RequestedBy = "User2",
                 BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -373,7 +373,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             var rulesEngine = new RulesEngineWrapper();
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.InProgress,
+                CurrentBuildStatus = BuildStatusEnum.InProgress,
                 Name = "New Name!",
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -470,7 +470,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             rulesEngine.InvokeStatusChecked(
                 new BuildStatus
                 {
-                    BuildStatusEnum = BuildStatusEnum.InProgress,
+                    CurrentBuildStatus = BuildStatusEnum.InProgress,
                     Name = "New Name!",
                     RequestedBy = RulesEngineWrapper.CURRENT_USER,
                     BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -492,7 +492,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             Assert.AreEqual(1, rulesEngine.Settings.People[0].GetReputation());
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.InProgress,
+                CurrentBuildStatus = BuildStatusEnum.InProgress,
                 Name = RulesEngineWrapper.BUILD1_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -501,7 +501,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             Assert.AreEqual(1, rulesEngine.Settings.People[0].GetReputation());
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.InProgress,
+                CurrentBuildStatus = BuildStatusEnum.InProgress,
                 Name = RulesEngineWrapper.BUILD1_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -579,7 +579,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             {
                 new BuildStatus
                 {
-                    BuildStatusEnum = BuildStatusEnum.Working,
+                    CurrentBuildStatus = BuildStatusEnum.Working,
                     Name = "Build Def 1",
                     RequestedBy = "User1",
                     BuildDefinitionId = "Build Def 1",
@@ -731,7 +731,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             rulesEngine.InvokeStatusChecked(
                 new BuildStatus
                 {
-                    BuildStatusEnum = BuildStatusEnum.InProgress,
+                    CurrentBuildStatus = BuildStatusEnum.InProgress,
                     Name = RulesEngineWrapper.BUILD1_ID,
                     RequestedBy = RulesEngineWrapper.CURRENT_USER,
                     BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -1144,7 +1144,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             Assert.AreEqual(0, build1Setting.People.Count);
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.Broken,
+                CurrentBuildStatus = BuildStatusEnum.Broken,
                 Name = RulesEngineWrapper.BUILD2_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD2_ID,
@@ -1168,7 +1168,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             Assert.AreEqual(0, build1Setting.People.Count);
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.Broken,
+                CurrentBuildStatus = BuildStatusEnum.Broken,
                 Name = RulesEngineWrapper.BUILD1_ID,
                 RequestedBy = "",
                 BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -1185,7 +1185,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             Assert.AreEqual(1, rulesEngine.RefreshStatusEvents.Count);
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 Name = RulesEngineWrapper.BUILD2_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD2_ID,
@@ -1194,7 +1194,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             Assert.AreEqual(2, rulesEngine.RefreshStatusEvents.Count);
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 Name = RulesEngineWrapper.BUILD2_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD2_ID,
@@ -1212,7 +1212,7 @@ namespace SirenOfShame.Test.Unit.Watcher
 
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 Name = RulesEngineWrapper.BUILD2_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD2_ID,
@@ -1222,7 +1222,7 @@ namespace SirenOfShame.Test.Unit.Watcher
 
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 Name = RulesEngineWrapper.BUILD2_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD2_ID,
@@ -1239,7 +1239,7 @@ namespace SirenOfShame.Test.Unit.Watcher
 
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 Name = RulesEngineWrapper.BUILD1_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD1_ID,
@@ -1248,7 +1248,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             Assert.AreEqual(2, rulesEngine.RefreshStatusEvents.Count);
             rulesEngine.InvokeStatusChecked(new BuildStatus
             {
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 Name = RulesEngineWrapper.BUILD2_ID,
                 RequestedBy = RulesEngineWrapper.CURRENT_USER,
                 BuildDefinitionId = RulesEngineWrapper.BUILD2_ID,
@@ -1300,7 +1300,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             Assert.AreEqual(new DateTime(2010, 1, 1, 1, 1, 1), buildDefinition.StartedTime);
             Assert.AreEqual(new DateTime(2010, 1, 1, 1, 10, 10), buildDefinition.FinishedTime);
             Assert.AreEqual(null, buildDefinition.Comment);
-            Assert.AreEqual(BuildStatusEnum.Broken, buildDefinition.BuildStatusEnum);
+            Assert.AreEqual(BuildStatusEnum.Broken, buildDefinition.CurrentBuildStatus);
         }
 
         [Test]

--- a/SirenOfShame.Test.Unit/Watcher/RulesEngineWrapper.cs
+++ b/SirenOfShame.Test.Unit/Watcher/RulesEngineWrapper.cs
@@ -124,7 +124,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             {
                 new BuildStatus
                 {
-                    BuildStatusEnum = status,
+                    CurrentBuildStatus = status,
                     Name = BUILD1_ID, 
                     RequestedBy = CURRENT_USER, 
                     BuildDefinitionId = BUILD1_ID, 

--- a/SirenOfShame.Test.Unit/Watcher/SosDbTest.cs
+++ b/SirenOfShame.Test.Unit/Watcher/SosDbTest.cs
@@ -52,7 +52,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             {
                 StartedTime = new DateTime(2010, 1, 1, 1, 1, 1),
                 FinishedTime = new DateTime(2010, 1, 1, 1, 1, 2),
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 BuildDefinitionId = "BuildDefinitionId",
                 BuildId = "BuildId",
                 Name = "Name",
@@ -76,7 +76,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             {
                 StartedTime = new DateTime(2010, 1, 1, 1, 1, 1),
                 FinishedTime = new DateTime(2010, 1, 1, 1, 1, 2),
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 BuildDefinitionId = "BuildDefinitionId",
                 BuildId = "BuildId",
                 Name = "Name",
@@ -100,7 +100,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             {
                 StartedTime = new DateTime(2010, 1, 1, 1, 1, 1),
                 FinishedTime = new DateTime(2010, 1, 1, 1, 1, 2),
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 BuildDefinitionId = "BuildDefinitionId",
                 BuildId = "BuildId",
                 Name = "Name",
@@ -138,7 +138,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             {
                 StartedTime = new DateTime(2010, 1, 1, 1, 1, 2),
                 FinishedTime = new DateTime(2010, 1, 1, 1, 1, 3),
-                BuildStatusEnum = BuildStatusEnum.Broken,
+                CurrentBuildStatus = BuildStatusEnum.Broken,
                 BuildDefinitionId = "BuildDefinitionId",
                 BuildId = "BuildId",
                 Name = "Name",
@@ -158,7 +158,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             BuildStatus buildStatus = new BuildStatus
             {
                 BuildDefinitionId = "BuildDefinitionId",
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 Comment = "hi",
                 FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1),
                 StartedTime = new DateTime(2010, 1, 1, 1, 1, 2),
@@ -184,7 +184,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             BuildStatus buildStatus = new BuildStatus
             {
                 BuildDefinitionId = "BuildDefinitionId",
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 Comment = "hi",
                 FinishedTime = new DateTime(2010, 1, 1, 1, 1, 1),
                 StartedTime = new DateTime(2010, 1, 1, 1, 1, 2),
@@ -213,7 +213,7 @@ namespace SirenOfShame.Test.Unit.Watcher
             BuildStatus buildStatus = new BuildStatus
             {
                 BuildDefinitionId = uglyBuildDefinition,
-                BuildStatusEnum = BuildStatusEnum.Working,
+                CurrentBuildStatus = BuildStatusEnum.Working,
                 Name = "BuildName",
             };
             SirenOfShameSettingsFake fakeSettings = new SirenOfShameSettingsFake();

--- a/SirenOfShame/BuildStats.cs
+++ b/SirenOfShame/BuildStats.cs
@@ -41,7 +41,7 @@ namespace SirenOfShame
             {
                 if (buildStatus == null || buildStatus.FinishedTime == null || buildStatus.StartedTime == null) continue;
                 var duration = buildStatus.FinishedTime.Value - buildStatus.StartedTime.Value;
-                Fill fill = buildStatus.BuildStatusEnum == BuildStatusEnum.Broken ? _failFill : _successFill;
+                Fill fill = buildStatus.CurrentBuildStatus == BuildStatusEnum.Broken ? _failFill : _successFill;
                 var bar = myPane.AddBar(null, null, new[] { duration.TotalMinutes }, Color.White);
                 bar.Bar.Fill = fill;
                 bar.Bar.Border.Color = Color.White;

--- a/TeamCityServices/TeamCityBuildStatus.cs
+++ b/TeamCityServices/TeamCityBuildStatus.cs
@@ -90,14 +90,14 @@ namespace TeamCityServices
                 StartedTime = GetTeamCityDate(startedTimeStr);
                 if (string.IsNullOrEmpty(finishedTimeStr))
                 {
-                    BuildStatusEnum = BuildStatusEnum.InProgress;
+                    CurrentBuildStatus = BuildStatusEnum.InProgress;
                 } 
                 else
                 {
                     FinishedTime = GetTeamCityDate(finishedTimeStr);
-                    BuildStatusEnum = ToBuildStatusEnum(status);
+                    CurrentBuildStatus = ToBuildStatusEnum(status);
 
-                    if (BuildStatusEnum == BuildStatusEnum.Unknown)
+                    if (CurrentBuildStatus == BuildStatusEnum.Unknown)
                     {
                         _log.Debug("Received an unknown build status from the following buildResult: " + buildResultXDoc);
                     }

--- a/TeamCityServices/TeamCityService.cs
+++ b/TeamCityServices/TeamCityService.cs
@@ -353,7 +353,7 @@ namespace TeamCityServices
                     if (title != null && title.Value.StartsWith("Cleanup in progress"))
                         throw new ServerUnavailableException("Cleanup in progress");
                     _log.Error("There was no changes element in the following XML: " + buildResultXDoc);
-                    return new TeamCityBuildStatus(buildDefinitionSetting) { BuildStatusEnum = BuildStatusEnum.Unknown };
+                    return new TeamCityBuildStatus(buildDefinitionSetting) { CurrentBuildStatus = BuildStatusEnum.Unknown };
                 }
                 var count = changesNode.AttributeValueOrDefault("count");
                 bool commentsExist = !string.IsNullOrEmpty(count) && count != "0";
@@ -411,7 +411,7 @@ namespace TeamCityServices
             {
                 return new TeamCityBuildStatus(buildDefinitionSetting)
                 {
-                    BuildStatusEnum = BuildStatusEnum.Unknown,
+                    CurrentBuildStatus = BuildStatusEnum.Unknown,
                     Comment = "[unable to connect to " + buildDefinitionSetting.Id + "]",
                 };
             }

--- a/TfsRestServices/TfsRestBuildStatus.cs
+++ b/TfsRestServices/TfsRestBuildStatus.cs
@@ -7,7 +7,7 @@ namespace TfsRestServices
     {
         public TfsRestBuildStatus(TfsJsonBuild tfsRestBuildDefinition, CommentsCache commentsCache)
         {
-            BuildStatusEnum = GetBuildStatus(tfsRestBuildDefinition);
+            CurrentBuildStatus = GetBuildStatus(tfsRestBuildDefinition);
             Name = tfsRestBuildDefinition.Definition.Name;
             BuildDefinitionId = tfsRestBuildDefinition.Definition.Id.ToString();
             RequestedBy = tfsRestBuildDefinition.RequestedFor.DisplayName;

--- a/TfsServices/Configuration/MyBuildServer.cs
+++ b/TfsServices/Configuration/MyBuildServer.cs
@@ -120,7 +120,7 @@ namespace TfsServices.Configuration
 
             var result = new BuildStatus
             {
-                BuildStatusEnum = buildStatus,
+                CurrentBuildStatus = buildStatus,
                 StartedTime = buildDetail.StartTime == DateTime.MinValue ? (DateTime?)null : buildDetail.StartTime,
                 FinishedTime = buildDetail.FinishTime == DateTime.MinValue ? (DateTime?)null : buildDetail.FinishTime,
             };

--- a/TravisCiServices/TravisCiBuildStatus.cs
+++ b/TravisCiServices/TravisCiBuildStatus.cs
@@ -14,7 +14,7 @@ namespace TravisCiServices
         {
             try
             {
-                BuildStatusEnum = ToBuildStatusEnum(TravisCiService.GetJsonValue(jsonDoc, "result"));
+                CurrentBuildStatus = ToBuildStatusEnum(TravisCiService.GetJsonValue(jsonDoc, "result"));
                 BuildDefinitionId = buildDefinitionSetting.Id;
                 Name = buildDefinitionSetting.Name;
                 RequestedBy = TravisCiService.GetJsonValue(jsonDoc, "author_name");


### PR DESCRIPTION
This fixes where on start up broken builds were always broken.  Now its wont determine new broken build until it has had at least one status update