### PR TITLE
Bugfix: Unhandled exception handler pop-up dialog for canceled TFS REST tasks

### DIFF
--- a/SirenOfShame.Lib/Watcher/WatcherBase.cs
+++ b/SirenOfShame.Lib/Watcher/WatcherBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using log4net;
 using SirenOfShame.Lib.Exceptions;
 using SirenOfShame.Lib.Settings;
@@ -71,6 +72,12 @@ namespace SirenOfShame.Lib.Watcher
             catch (ThreadAbortException)
             {
                 _log.Debug("Stopped watching build status (ThreadAbortException)");
+                StopWatching();
+                OnStoppedWatching();
+            }
+            catch (TaskCanceledException)
+            {
+                _log.Debug("Stopped watching build status (TaskCanceledException)");
                 StopWatching();
                 OnStoppedWatching();
             }

--- a/TfsRestServices/TfsRestWatcher.cs
+++ b/TfsRestServices/TfsRestWatcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using SirenOfShame.Lib.Exceptions;
 using SirenOfShame.Lib.Settings;
 using SirenOfShame.Lib.Watcher;
@@ -37,6 +38,12 @@ namespace TfsRestServices
                 if (anyServerUnavailable)
                 {
                     throw new ServerUnavailableException();
+                }
+
+                var taskCancelledException = ex.InnerExceptions.FirstOrDefault(x => x is TaskCanceledException);
+                if (!ReferenceEquals(null, taskCancelledException))
+                {
+                    throw taskCancelledException;
                 }
                 throw;
             }


### PR DESCRIPTION
 TFS REST service sometimes raises this exception. When propagated up the stack the exception may be wrapped in an AggregateException.