### PR TITLE
Fixes issue #106 where the build succeeds rule isn't always fired

### DIFF
--- a/SirenOfShame.Lib/Settings/Rule.cs
+++ b/SirenOfShame.Lib/Settings/Rule.cs
@@ -167,7 +167,7 @@ namespace SirenOfShame.Lib.Settings
             if (TriggerType == TriggerType.InitialSuccess           && newlyFixed) return true;
             if (TriggerType == TriggerType.BuildTriggered           && buildStatus.BuildStatusEnum == BuildStatusEnum.InProgress) return true;
             if (TriggerType == TriggerType.SubsequentFailedBuild    && buildStatus.BuildStatusEnum == BuildStatusEnum.Broken && !newlyBroken) return true;
-            if (TriggerType == TriggerType.SuccessfulBuild          && buildStatus.BuildStatusEnum == BuildStatusEnum.Working && !newlyFixed) return true;
+            if (TriggerType == TriggerType.SuccessfulBuild          && buildStatus.BuildStatusEnum == BuildStatusEnum.Working) return true;
             return false;
         }
 

--- a/SirenOfShame.Test.Unit/Watcher/RulesEngineTest.cs
+++ b/SirenOfShame.Test.Unit/Watcher/RulesEngineTest.cs
@@ -806,7 +806,7 @@ namespace SirenOfShame.Test.Unit.Watcher
         }
 
         [Test]
-        public void BuidFailsThenSucceedsWithGlobalSubsequentSuccessAlerts_NoAlert()
+        public void BuildFailsThenSucceedsWithSuccessfulBuildTrigger_TriggersAlert()
         {
             var rulesEngine = new RulesEngineWrapper();
 
@@ -815,11 +815,10 @@ namespace SirenOfShame.Test.Unit.Watcher
                 TriggerType = TriggerType.SuccessfulBuild,
                 AlertType = AlertType.TrayAlert
             });
-
             rulesEngine.InvokeStatusChecked(BuildStatusEnum.Broken);
             rulesEngine.InvokeStatusChecked(BuildStatusEnum.InProgress);
             rulesEngine.InvokeStatusChecked(BuildStatusEnum.Working);
-            Assert.AreEqual(0, rulesEngine.TrayNotificationEvents.Count);
+            Assert.AreEqual(1, rulesEngine.TrayNotificationEvents.Count);
         }
 
         [Test]
@@ -858,9 +857,9 @@ namespace SirenOfShame.Test.Unit.Watcher
             rulesEngine.InvokeStatusChecked(BuildStatusEnum.Working);
             rulesEngine.InvokeStatusChecked(BuildStatusEnum.InProgress);
             rulesEngine.InvokeStatusChecked(BuildStatusEnum.Working);
-            Assert.AreEqual(1, rulesEngine.TrayNotificationEvents.Count);
-            Assert.AreEqual("Build Passing", rulesEngine.TrayNotificationEvents[0].Title);
-            Assert.AreEqual("Build passed for Build Def 1", rulesEngine.TrayNotificationEvents[0].TipText);
+            Assert.AreEqual(2, rulesEngine.TrayNotificationEvents.Count);
+            Assert.AreEqual("Build Passing", rulesEngine.TrayNotificationEvents[1].Title);
+            Assert.AreEqual("Build passed for Build Def 1", rulesEngine.TrayNotificationEvents[1].TipText);
         }
 
         [Test]


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fixes Issue #106 where failed builds don't always fire.

### :arrow_heading_down: What is the current behavior?

If you have a failed build and then a successful build then successful rules aren't firing.

### :new: What is the new behavior (if this is a feature change)?

The rules will now fire as expected.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing



### :memo: Links to relevant issues/docs

Issue #106 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Rebased onto current develop
- [x] Ensure unit tests pass
- [x] Write at least one new unit test (if possible)