### PR TITLE
Bug #112: tfs lockup

### DIFF
--- a/SirenOfShame.Test.Unit/TfsRestServices/TfsRestWatcherTest.cs
+++ b/SirenOfShame.Test.Unit/TfsRestServices/TfsRestWatcherTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net;
+using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using SirenOfShame.Lib.Exceptions;
@@ -89,6 +90,23 @@ namespace SirenOfShame.Test.Unit.TfsRestServices
             var ciEntryPointSetting = new CiEntryPointSetting { Url = "url" };
             tfsRestService.Setup(i => i.GetBuildsStatuses(ciEntryPointSetting, buildDefinitionSettings))
                 .ThrowsAsync(new System.Net.Http.HttpRequestException("Unable to connect to the remote server"));
+            var tfsRestWatcher = new MyTfsRestWatcher(tfsRestService.Object, buildDefinitionSettings, ciEntryPointSetting);
+
+            // assert & act
+            Assert.Throws<ServerUnavailableException>(() =>
+                tfsRestWatcher.MyGetBuildStatus()
+            );
+        }
+
+        [Test]
+        public void GivenTaskCanceledExceptionAkaTimeout_WhenGettingBuildStatus_ThenServerUnavailableException()
+        {
+            // arrange
+            var buildDefinitionSettings = new[] {new BuildDefinitionSetting()};
+            var tfsRestService = new Mock<TfsRestService>();
+            var ciEntryPointSetting = new CiEntryPointSetting { Url = "url" };
+            tfsRestService.Setup(i => i.GetBuildsStatuses(ciEntryPointSetting, buildDefinitionSettings))
+                .ThrowsAsync(new TaskCanceledException());
             var tfsRestWatcher = new MyTfsRestWatcher(tfsRestService.Object, buildDefinitionSettings, ciEntryPointSetting);
 
             // assert & act

--- a/TfsRestServices/ServerConfiguration/ConfigureTfsRest.Designer.cs
+++ b/TfsRestServices/ServerConfiguration/ConfigureTfsRest.Designer.cs
@@ -216,6 +216,7 @@
             // _vstsLink
             // 
             this._vstsLink.ActiveLinkColor = System.Drawing.Color.White;
+            this._vstsLink.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this._vstsLink.AutoSize = true;
             this._vstsLink.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(230)))), ((int)(((byte)(230)))), ((int)(((byte)(230)))));
             this._vstsLink.Location = new System.Drawing.Point(396, 59);

--- a/TfsRestServices/TfsRestServices.csproj
+++ b/TfsRestServices/TfsRestServices.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
+    <OutputPath>..\SirenOfShame\bin\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>

--- a/TfsRestServices/TfsRestWatcher.cs
+++ b/TfsRestServices/TfsRestWatcher.cs
@@ -46,11 +46,6 @@ namespace TfsRestServices
                     throw new ServerUnavailableException();
                 }
 
-                var taskCancelledException = ex.InnerExceptions.FirstOrDefault(x => x is TaskCanceledException);
-                if (!ReferenceEquals(null, taskCancelledException))
-                {
-                    throw taskCancelledException;
-                }
                 throw;
             }
             catch (WebException ex)
@@ -75,6 +70,8 @@ namespace TfsRestServices
 
         private static bool IsServerUnavailable(Exception ex)
         {
+            if (ex is TaskCanceledException)
+                return true;
             if (ex is WebException webException)
                 return IsServerUnavailable(webException);
             if (ex is HttpRequestException httpRequestException)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When a timeout occurs connecting to TFS then sos treats it as an unexpected exception and stops watching.

### :new: What is the new behavior (if this is a feature change)?

When a timeout now occurs sos treats it as server unavailable and pauses and tries to reconnect.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Fiddler, see: https://stackoverflow.com/questions/11582667/how-to-simulate-timeouts-with-fiddler

### :memo: Links to relevant issues/docs

https://github.com/AutomatedArchitecture/SirenOfShame/issues/112

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Rebased onto current develop
- [x] Ensure unit tests pass
- [x] Write at least one new unit test (if possible)