### PR TITLE
Fix multiple simultaneous builds of the same BuildDefinitionID

### DIFF
--- a/SirenOfShame.Lib/Util/BuildStatusUtil.cs
+++ b/SirenOfShame.Lib/Util/BuildStatusUtil.cs
@@ -17,16 +17,18 @@ namespace SirenOfShame.Lib.Util
             var oldBuildStatusesToRetain = oldBuildStatuses.Except(newBuildStatuses, buildStatusComparer);
             var newBuildStatusesToAdd = newBuildStatuses.Except(oldBuildStatuses, buildStatusComparer);
             var unchangedBuildStatuses = from oldStatus in oldBuildStatuses
-                                         join newStatus in newBuildStatuses on oldStatus.BuildDefinitionId equals newStatus.BuildDefinitionId
+                                         join newStatus in newBuildStatuses on oldStatus.BuildId equals newStatus.BuildId
                                          where newStatus.BuildStatusEnum == oldStatus.BuildStatusEnum &&
                                             newStatus.StartedTime == oldStatus.StartedTime
                                          select oldStatus;
             var changedBuildStatuses = from oldStatus in oldBuildStatuses
-                                       join newStatus in newBuildStatuses on oldStatus.BuildDefinitionId equals newStatus.BuildDefinitionId
+                                       join newStatus in newBuildStatuses on oldStatus.BuildId equals newStatus.BuildId
                                        where newStatus.BuildStatusEnum != oldStatus.BuildStatusEnum ||
                                             newStatus.StartedTime != oldStatus.StartedTime
                                        select newStatus;
-            return oldBuildStatusesToRetain.Union(newBuildStatusesToAdd).Union(unchangedBuildStatuses).Union(changedBuildStatuses).ToArray();
+            var duplicateBuildDefIDs = oldBuildStatusesToRetain.Union(newBuildStatusesToAdd).Union(unchangedBuildStatuses).Union(changedBuildStatuses);
+            var distinct = duplicateBuildDefIDs.OrderBy(x => x.StartedTime).GroupBy(x => x.BuildDefinitionId).Select(y => y.LastOrDefault());
+            return distinct.ToArray();
         }
     }
 
@@ -36,7 +38,7 @@ namespace SirenOfShame.Lib.Util
         {
             if (x == null && y == null) return true;
             if (x == null || y == null) return false;
-            return x.BuildDefinitionId == y.BuildDefinitionId;
+            return x.BuildId == y.BuildId;
         }
 
         public int GetHashCode(BuildStatus obj)

--- a/SirenOfShame.Lib/Util/BuildStatusUtil.cs
+++ b/SirenOfShame.Lib/Util/BuildStatusUtil.cs
@@ -17,12 +17,12 @@ namespace SirenOfShame.Lib.Util
             var oldBuildStatusesToRetain = oldBuildStatuses.Except(newBuildStatuses, buildStatusComparer);
             var newBuildStatusesToAdd = newBuildStatuses.Except(oldBuildStatuses, buildStatusComparer);
             var unchangedBuildStatuses = from oldStatus in oldBuildStatuses
-                                         join newStatus in newBuildStatuses on oldStatus.BuildId equals newStatus.BuildId
+                                         join newStatus in newBuildStatuses on oldStatus.UniqueId equals newStatus.UniqueId
                                          where newStatus.BuildStatusEnum == oldStatus.BuildStatusEnum &&
                                             newStatus.StartedTime == oldStatus.StartedTime
                                          select oldStatus;
             var changedBuildStatuses = from oldStatus in oldBuildStatuses
-                                       join newStatus in newBuildStatuses on oldStatus.BuildId equals newStatus.BuildId
+                                       join newStatus in newBuildStatuses on oldStatus.UniqueId equals newStatus.UniqueId
                                        where newStatus.BuildStatusEnum != oldStatus.BuildStatusEnum ||
                                             newStatus.StartedTime != oldStatus.StartedTime
                                        select newStatus;
@@ -38,7 +38,7 @@ namespace SirenOfShame.Lib.Util
         {
             if (x == null && y == null) return true;
             if (x == null || y == null) return false;
-            return x.BuildId == y.BuildId;
+            return x.UniqueId == y.UniqueId;
         }
 
         public int GetHashCode(BuildStatus obj)

--- a/SirenOfShame.Lib/Watcher/BuildStatus.cs
+++ b/SirenOfShame.Lib/Watcher/BuildStatus.cs
@@ -86,6 +86,15 @@ namespace SirenOfShame.Lib.Watcher
         public string BuildStatusMessage { get; set; }
         public string Comment { get; set; }
 
+        /// <summary>
+        /// Combines the build definition id and the build id for the purpose of uniquely
+        /// identifying a build in a dictionary and determining if a build is new
+        /// </summary>
+        public string UniqueId
+        {
+            get { return $"{BuildDefinitionId}-{BuildId}"; }
+        }
+
         public string BuildStatusDescription
         {
             get { return BuildStatusToString(BuildStatusEnum); }

--- a/SirenOfShame.Lib/Watcher/RulesEngine.cs
+++ b/SirenOfShame.Lib/Watcher/RulesEngine.cs
@@ -307,7 +307,7 @@ namespace SirenOfShame.Lib.Watcher
             var oldBuildStatus = _previousBuildStatuses;
             _previousBuildStatuses = allBuildStatuses;
             var changedBuildStatuses = from newStatus in allBuildStatuses
-                                       from oldStatus in oldBuildStatus.Where(s => s.BuildDefinitionId == newStatus.BuildDefinitionId).DefaultIfEmpty()
+                                       from oldStatus in oldBuildStatus.Where(s => s.BuildId == newStatus.BuildId).DefaultIfEmpty()
                                        where DidBuildStatusChange(oldStatus, newStatus)
                                        select newStatus;
             

--- a/SirenOfShame.Lib/Watcher/RulesEngine.cs
+++ b/SirenOfShame.Lib/Watcher/RulesEngine.cs
@@ -307,7 +307,7 @@ namespace SirenOfShame.Lib.Watcher
             var oldBuildStatus = _previousBuildStatuses;
             _previousBuildStatuses = allBuildStatuses;
             var changedBuildStatuses = from newStatus in allBuildStatuses
-                                       from oldStatus in oldBuildStatus.Where(s => s.BuildId == newStatus.BuildId).DefaultIfEmpty()
+                                       from oldStatus in oldBuildStatus.Where(s => s.UniqueId == newStatus.UniqueId).DefaultIfEmpty()
                                        where DidBuildStatusChange(oldStatus, newStatus)
                                        select newStatus;
             

--- a/SirenOfShame.Test.Unit/Util/BuildStatusUtilTest.cs
+++ b/SirenOfShame.Test.Unit/Util/BuildStatusUtilTest.cs
@@ -10,7 +10,22 @@ namespace SirenOfShame.Test.Unit.Util
     public class BuildStatusUtilTest
     {
         [Test]
-        public void Merge_NewBuildStatus_Added()
+        public void GivenOneOldStatus_WhenTwoNewBuildsExistWithSameBuildDefinitionId_ThenNewestIsReturned()
+        {
+            var oldStatus = new[] { new BuildStatus { BuildDefinitionId = "BD1", BuildId = "B1", BuildStatusEnum = BuildStatusEnum.Working } };
+            var newStatuses = new[]
+            {
+                new BuildStatus {BuildDefinitionId = "BD1", BuildId = "B2", BuildStatusEnum = BuildStatusEnum.InProgress, StartedTime = new DateTime(2018, 1, 1, 2, 2, 3) },
+                new BuildStatus {BuildDefinitionId = "BD1", BuildId = "B3", BuildStatusEnum = BuildStatusEnum.InProgress, StartedTime = new DateTime(2018, 1, 1, 2, 2, 2)}
+            };
+            var buildStatuses = BuildStatusUtil.Merge(oldStatus, newStatuses);
+            Assert.AreEqual(1, buildStatuses.Length);
+            var buildStatuse = buildStatuses[0];
+            Assert.AreEqual("B2", buildStatuse.BuildId);
+        }
+
+        [Test]
+        public void GivenEmptyOldStatus_WhenNewBuildStatusExists_ThenNewBuildStatusIsAdded()
         {
             var oldStatus = new BuildStatus[] {};
             var newStatuses = new[] {new BuildStatus {BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working}};
@@ -21,7 +36,7 @@ namespace SirenOfShame.Test.Unit.Util
         }
         
         [Test]
-        public void Merge_RemovedBuildStatus_Retained()
+        public void GivenAnOldBuildStatus_WhenEmptyNewBuildStatusMerged_ThenOldBuildStatusIsRetained()
         {
             var oldStatus = new[] {new BuildStatus {BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working}};
             var newStatuses = new BuildStatus[] {};
@@ -30,7 +45,7 @@ namespace SirenOfShame.Test.Unit.Util
         }
 
         [Test]
-        public void Merge_ExistingUnchangedBuildStatus_NotOverwritten()
+        public void GivenOldBuildStatus_WhenBuildStatusWithSameIdIsMerged_ThenOldBuildStatusIsNotOverwritten()
         {
             var oldStatus = new[] { new BuildStatus { BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working, LocalStartTime = new DateTime(2010, 1, 1) } };
             var newStatuses = new[] { new BuildStatus { BuildDefinitionId = "1", BuildStatusEnum = BuildStatusEnum.Working, LocalStartTime = new DateTime(2012, 2, 2)} };

--- a/SirenOfShame.Test.Unit/Watcher/BuildStatusTest.cs
+++ b/SirenOfShame.Test.Unit/Watcher/BuildStatusTest.cs
@@ -10,6 +10,17 @@ namespace SirenOfShame.Test.Unit.Watcher
     public class BuildStatusTest
     {
         [Test]
+        public void UniqueId_ContainsBuildDefinitionAndBuildId()
+        {
+            var buildStatus = new BuildStatus
+            {
+                BuildId = "1",
+                BuildDefinitionId = "2"
+            };
+            Assert.AreEqual("2-1", buildStatus.UniqueId);
+        }
+
+        [Test]
         public void Parse_InvalidDate()
         {
             var actual = BuildStatus.Parse(new [] { "63460976461000000Z", "", "1", "jshimpty" }, "buildid");


### PR DESCRIPTION
Cope with multiple simultaneous builds of a watched build being in progress at once.  Instead of using the BuildDefinitionId, use the BuildID as the latter should be guaranteed to be unique.  Once build statuses have been gathered for all requested BuildDefinitionIDs, ensure the returned entries are unique for BuildDefinitionID by sorting by start time, grouping and taking the last entry (the most recently started build).

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix for https://github.com/AutomatedArchitecture/SirenOfShame/issues/120 - Multiple simultaneous builds of the same BuildDefinitionID break the merging and status updating code for BuildStatus objects.


### :arrow_heading_down: What is the current behavior?

See raised issue - https://github.com/AutomatedArchitecture/SirenOfShame/issues/120.  Gui becomes unresponsive and app eventually crashes with OOM as every single build status update generates exponentially more build statuses.

### :new: What is the new behavior (if this is a feature change)?

BuildStatuses are now returned uniquely  on BuildDefinitionID by instead altering the linq queries to work on the (presumed unique?) BuildID field, and if multiple builds with the same BuildDefinitionID are found then the most recently started build is used.

### :boom: Does this PR introduce a breaking change?

It shouldn't, but I've not been able to test this on any other platform than TeamCity.  As long as BuildID represents a unique build from the server then it should be fine.

### :bug: Recommendations for testing

Have multiple agents in a TeamCity pool and trigger multiple builds of a type added to Siren Of Shame.  Set the siren of shame update interval to be pretty frequent, and watch as the number of reported build boxes increases exponentially until the gui becomes unresponsive.  After this patch, one box per watched build will be shown, and the status of the most recently started build will be reflected.

### :memo: Links to relevant issues/docs

https://github.com/AutomatedArchitecture/SirenOfShame/issues/120

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Rebased onto current develop
- [x] Ensure unit tests pass
- [ ] Write at least one new unit test (if possible) - Yeah, I know, I'm Bad Programmer, but super busy at the moment and can't be without the Siren!