### PR TITLE
Restore form position and size at startup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+
+[*.csproj]
+indent_style = space
+indent_size = 2

--- a/SirenOfShame.Lib/Settings/SirenOfShameSettings.cs
+++ b/SirenOfShame.Lib/Settings/SirenOfShameSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -210,6 +211,9 @@ namespace SirenOfShame.Lib.Settings
         public bool AlwaysOnTop { get; set; }
 
         public bool StartInFullScreen { get; set; }
+        public Size? StartWithSize { get; set; }
+        public int StartAtLeftPosition { get; set; }
+        public int StartAtTopPosition { get; set; }
 
         public bool ShowNewsfeed { get; set; }
 

--- a/SirenOfShame/MainForm.cs
+++ b/SirenOfShame/MainForm.cs
@@ -73,9 +73,22 @@ namespace SirenOfShame
                 // it seems to be necessary to set a baseline font size
                 SetFontSize(SirenOfShameSettings.DEFAULT_FONT_SIZE);
                 SetFontSize(lastFontSize);
+                RestoreFormPosition();
             }
             _newsFeed1.Visible = _settings.ShowNewsfeed;
             _userList.Visible = _settings.ShowLeaders;
+        }
+
+        private void RestoreFormPosition()
+        {
+            if (!_settings.StartInFullScreen && _settings.StartWithSize.HasValue)
+            {
+                if (_settings.StartAtTopPosition >= 0)
+                    this.Top = _settings.StartAtTopPosition;
+                if (_settings.StartAtLeftPosition >= 0)
+                    this.Left = _settings.StartAtLeftPosition;
+                this.Size = _settings.StartWithSize.Value;
+            }
         }
 
         protected virtual SirenOfShameSettings GetAppSettings()
@@ -562,7 +575,18 @@ namespace SirenOfShame
             else
             {
                 RulesEngine.Stop();
+                SaveFormPosition();
             }
+        }
+
+        private void SaveFormPosition()
+        {
+            _settings.StartWithSize = Size;
+            if (_settings.StartAtTopPosition >= 0)
+                _settings.StartAtTopPosition = Top;
+            if (_settings.StartAtLeftPosition >= 0)
+                _settings.StartAtLeftPosition = Left;
+            _settings.Save();
         }
 
         // this is a hack to determine if we are being called by wyUpdate


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?

The size and position of the main window is not restored and the startup (so we have to manually resize and move it at each startup)


### :new: What is the new behavior (if this is a feature change)?
The size and position of the main window is saved when closing ans restored at startup


### :boom: Does this PR introduce a breaking change?
No

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Rebased onto current develop
- [x] Ensure unit tests pass
- [ ] Write at least one new unit test (if possible)